### PR TITLE
Create Jumpbox with Security Group for Console-Only SSH Access Using EC2 Instance Connect Prefix Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # IaC_Lab1
 Infrastructure as a Code - Lab 1 - Cloud Formation Templates  
+
+Student Robert Szlufik

--- a/ec2-template.yml
+++ b/ec2-template.yml
@@ -1,32 +1,36 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: Create an EC2 instance with a security group that allows SSH access and a new key pair
+
+Parameters:
+
+  Ec2InstanceConnectPrefixList:
+    Type: String
+    Default: "pl-0e4bcff02b13bef1e"
+
 
 Resources:
   MyEC2Instance:
-    Type: 'AWS::EC2::Instance'
-    Properties: 
+    Type: "AWS::EC2::Instance"
+    Properties:
       InstanceType: t2.micro
       ImageId: ami-0fff1b9a61dec8a5f
-      KeyName: !Ref SshKeyPair
       SecurityGroups:
         - !Ref SshSecurityGroup
 
   SshSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: "AWS::EC2::SecurityGroup"
     Properties:
-      GroupDescription: Enable SSH access
+      GroupDescription: "Allow SSH access only via AWS EC2 Instance Connect From the Same AZ"
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: '22'
-          ToPort: '22'
-          CidrIp: 0.0.0.0/0
-
-  SshKeyPair:
-    Type: 'AWS::EC2::KeyPair'
-    Properties:
-      KeyName: key-pair-lab1 
-
+          FromPort: 22
+          ToPort: 22
+          SourcePrefixListId: !Ref Ec2InstanceConnectPrefixList
 Outputs:
-  KeyPairName:
-    Description: The name of the key pair
-    Value: !Ref SshKeyPair
+  InstancePublicIP:
+    Description: "The public IP address of the EC2 instance"
+    Value: !GetAtt MyEC2Instance.PublicIp
+
+  SelectedRegionOutput:
+    Description: "The AWS region where the stack is deployed"
+    Value: !Ref SelectedRegion

--- a/ec2-template.yml
+++ b/ec2-template.yml
@@ -2,6 +2,15 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: Create an EC2 instance with a security group that allows SSH access and a new key pair
 
 Parameters:
+  SelectedRegion:
+    Type: String
+    Default: "us-east-1"
+    AllowedValues:
+      - "us-east-1"
+      - "us-west-1"
+      - "eu-west-1"
+      - "eu-central-1"
+    Description: "Select the AWS region where the stack will be deployed"
 
   Ec2InstanceConnectPrefixList:
     Type: String

--- a/ec2-template.yml
+++ b/ec2-template.yml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Create an EC2 instance with a security group that allows SSH access and a new key pair
+
+Resources:
+  MyEC2Instance:
+    Type: 'AWS::EC2::Instance'
+    Properties: 
+      InstanceType: t2.micro
+      ImageId: ami-0fff1b9a61dec8a5f
+      KeyName: !Ref SshKeyPair
+      SecurityGroups:
+        - !Ref SshSecurityGroup
+
+  SshSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Enable SSH access
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: 0.0.0.0/0
+
+  SshKeyPair:
+    Type: 'AWS::EC2::KeyPair'
+    Properties:
+      KeyName: key-pair-lab1 
+
+Outputs:
+  KeyPairName:
+    Description: The name of the key pair
+    Value: !Ref SshKeyPair

--- a/ec2-template.yml
+++ b/ec2-template.yml
@@ -9,13 +9,20 @@ Parameters:
       - "us-east-1"
       - "us-west-1"
       - "eu-west-1"
-      - "eu-central-1"
     Description: "Select the AWS region where the stack will be deployed"
 
-  Ec2InstanceConnectPrefixList:
-    Type: String
-    Default: "pl-0e4bcff02b13bef1e"
+  # Ec2InstanceConnectPrefixList:
+  #   Type: String
+  #   Default: "pl-0e4bcff02b13bef1e"
 
+Mappings:
+  RegionToPrefixList:
+    us-east-1:
+      PrefixList: "pl-0e4bcff02b13bef1e"
+    us-west-1:
+      PrefixList: "pl-0e99958a47b22d6ab"
+    eu-west-1:
+      PrefixList: "pl-0839cc4c195a4e751"
 
 Resources:
   MyEC2Instance:
@@ -34,11 +41,11 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          SourcePrefixListId: !Ref Ec2InstanceConnectPrefixList
+          SourcePrefixListId: !FindInMap [RegionToPrefixList, !Ref SelectedRegion, PrefixList]
 Outputs:
   InstancePublicIP:
     Description: "The public IP address of the EC2 instance"
-    Value: !GetAtt MyEC2Instance.PublicIp
+    Value: !Ref SshSecurityGroup
 
   SelectedRegionOutput:
     Description: "The AWS region where the stack is deployed"


### PR DESCRIPTION
This Pull Request adds a Jumpbox EC2 instance with a security group that restricts SSH access only from the AWS Console, specifically using the EC2 Instance Connect service. The security group dynamically selects the correct managed prefix list for EC2 Instance Connect based on the region where the stack is deployed.

### CloudFormation Template to:
 - Create an EC2 instance in the region specified during stack deployment.
 - Attach a security group that allows SSH access only from EC2 Instance Connect by referencing region-specific managed prefix lists.
 - Dynamically select the correct prefix list based on the selected region (us-east-1, us-west-1, eu-west-1).


Closes #1 