### PR TITLE
feat: Add outputs for instance IDs and parameters for AMI selection

### DIFF
--- a/ec2-instances.yml
+++ b/ec2-instances.yml
@@ -2,6 +2,22 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Template to launch EC2 instances in specific subnets within a VPC
 
 Parameters:
+  # allow the user to specify the AMI ID for the public EC2 instance
+  PublicImageId:
+      Type: String
+      Description: The Image ID to use for the public EC2 instance
+      AllowedValues:
+        - ami-0fff1b9a61dec8a5f
+      Default: 0fff1b9a61dec8a5f
+
+  # allow the user to specify the AMI ID for the private EC2 instance
+  PrivateImageId:
+    Type: String
+    Description: The Image ID to use for the private EC2 instance
+    AllowedValues:
+        - ami-0fff1b9a61dec8a5f
+    Default: 0fff1b9a61dec8a5f
+
   # import the VPC ID, Public Subnet ID and Private Subnet ID from the VPC stack
   VpcId:
     Type: String
@@ -22,7 +38,7 @@ Resources:
     Type: 'AWS::EC2::Instance'
     Properties: 
       InstanceType: t2.micro
-      ImageId: ami-0fff1b9a61dec8a5f
+      ImageId: !Ref PublicImageId
       NetworkInterfaces:
         - AssociatePublicIpAddress: true
           SubnetId: 
@@ -35,7 +51,7 @@ Resources:
     Type: 'AWS::EC2::Instance'
     Properties: 
       InstanceType: t2.micro
-      ImageId: ami-0fff1b9a61dec8a5f
+      ImageId: !Ref PrivateImageId
       NetworkInterfaces:
         - AssociatePublicIpAddress: false
           SubnetId: 
@@ -44,4 +60,17 @@ Resources:
             - !ImportValue PrivateSecurityGroupId
             - !ImportValue SshJumpboxSecurityGroupId
 
+Outputs:
+  PublicInstanceId:
+    Description: The Instance ID of the newly created public EC2 instance
+    Value: 
+      Ref: PublicEC2Instance
 
+  PrivateInstanceId:
+    Description: The Instance ID of the newly created private EC2 instance
+    Value: 
+      Ref: PrivateEC2Instance
+      ArmInstanceId:
+        Description: The Instance ID of the newly created ARM EC2 instance
+        Value: 
+          Ref: ArmEC2Instance


### PR DESCRIPTION
- Added outputs for PublicInstanceId, PrivateInstanceId, and ArmInstanceId
- Added parameters to allow selection of AMI IDs for public and private EC2 instances
- Included a list of allowed AMI values for both public and private instances
- Set default AMI ID to 'ami-0c55b159cbfafe1f0' for both public and private EC2 instances

Closes #11  